### PR TITLE
promise.ensure

### DIFF
--- a/lib/D.js
+++ b/lib/D.js
@@ -103,6 +103,7 @@
 			}
 		;
 		_promise.toSource = _promise.toString = _promise.valueOf = function(){return value === undef ? this : value; };
+		_promise.otherwise = _promise.error; // alias
 
 		function execCallbacks(){
 			if ( status === 0 ) {


### PR DESCRIPTION
Hi,

when (https://github.com/cujojs/when/blob/master/when.js) has a nice 'ensure' feature.
'ensure' function will always be called, no matter if the promise is resolved or rejected.
It is useful for cleanup, etc.

Yoni.
