### PR TITLE
Checking for module.exports first, then setting D.js on window object

### DIFF
--- a/lib/D.js
+++ b/lib/D.js
@@ -437,6 +437,8 @@
 	/*global define*/
 	if ( typeof define === 'function' && define.amd ) {
 		define('D.js', [], function(){ return defer; });
+	} else if ( typeof module !== undefStr && module.exports ) {
+		module.exports = defer;
 	} else if ( typeof window !== undefStr ) {
 		var oldD = window.D;
 		/**
@@ -448,7 +450,5 @@
 			return defer;
 		};
 		window.D = defer;
-	} else if ( typeof module !== undefStr && module.exports ) {
-		module.exports = defer;
 	}
 })();


### PR DESCRIPTION
I'm playing around with an Atom package. Since Atom has a global `window` object defined, the module wasn't exported using `module.exports`.